### PR TITLE
fixing issue while doing inference on cpu

### DIFF
--- a/audio_restoration_model.py
+++ b/audio_restoration_model.py
@@ -54,8 +54,7 @@ def load_model(save_path):
     """
 
     optimized_model = OptimizedAudioRestorationModel()
-    state_dict = torch.load(save_path)
-
+    state_dict = torch.load(save_path, map_location=torch.device(device))
     if 'model_state_dict' in state_dict:
         state_dict = state_dict['model_state_dict']
     optimized_model.voice_restore.load_state_dict(state_dict, strict=True)


### PR DESCRIPTION
I have tried running the code on a CPU and faced the following issue:

```bash
python audio_restoration_model.py --checkpoint ./checkpoints/voice-restore-20d-16h-optim.pt --input test_input.wav --output test_output.wav --steps 64 --cfg_strength 0.5

>>> config.json: 100%|███████████████████████████████████████████████████████████████| 1.40k/1.40k [00:00<00:00, 3.61MB/s]
/Users/fabiocat/miniconda3/envs/restore/lib/python3.10/site-packages/torch/nn/utils/weight_norm.py:134: FutureWarning: torch.nn.utils.weight_norm is deprecated in favor of torch.nn.utils.parametrizations.weight_norm.
  WeightNorm.apply(module, name, dim)
Loading weights from nvidia/bigvgan_v2_24khz_100band_256x
bigvgan_generator.pt: 100%|████████████████████████████████████████████████████████| 450M/450M [00:44<00:00, 10.2MB/s]
/Users/fabiocat/Documents/git/voicerestore/BigVGAN/bigvgan.py:482: FutureWarning: You are using torch.load with weights_only=False (the current default value), which uses the default pickle module implicitly. It is possible to construct malicious pickle data which will execute arbitrary code during unpickling (See https://github.com/pytorch/pytorch/blob/main/SECURITY.md#untrusted-models for more details). In a future release, the default value for weights_only will be flipped to True. This limits the functions that could be executed during unpickling. Arbitrary objects will no longer be allowed to be loaded via this mode unless they are explicitly allowlisted by the user via torch.serialization.add_safe_globals. We recommend you start setting weights_only=True for any use case where you don't have full control of the loaded file. Please open an issue on GitHub for any issues related to this experimental feature.
  checkpoint_dict = torch.load(model_file, map_location=map_location)
Removing weight norm...
[WARNING] Min value of input waveform signal is -4.205924987792969
[WARNING] Max value of input waveform signal is 3.7423627376556396
/Users/fabiocat/Documents/git/voicerestore/audio_restoration_model.py:57: FutureWarning: You are using torch.load with weights_only=False (the current default value), which uses the default pickle module implicitly. It is possible to construct malicious pickle data which will execute arbitrary code during unpickling (See https://github.com/pytorch/pytorch/blob/main/SECURITY.md#untrusted-models for more details). In a future release, the default value for weights_only will be flipped to True. This limits the functions that could be executed during unpickling. Arbitrary objects will no longer be allowed to be loaded via this mode unless they are explicitly allowlisted by the user via torch.serialization.add_safe_globals. We recommend you start setting weights_only=True for any use case where you don't have full control of the loaded file. Please open an issue on GitHub for any issues related to this experimental feature.
  state_dict = torch.load(save_path)
Traceback (most recent call last):
  File "/Users/fabiocat/Documents/git/voicerestore/audio_restoration_model.py", line 94, in <module>
    optimized_model = load_model(args.checkpoint)
  File "/Users/fabiocat/Documents/git/voicerestore/audio_restoration_model.py", line 57, in load_model
    state_dict = torch.load(save_path)
  File "/Users/fabiocat/miniconda3/envs/restore/lib/python3.10/site-packages/torch/serialization.py", line 1097, in load
    return _load(
  File "/Users/fabiocat/miniconda3/envs/restore/lib/python3.10/site-packages/torch/serialization.py", line 1525, in _load
    result = unpickler.load()
  File "/Users/fabiocat/miniconda3/envs/restore/lib/python3.10/site-packages/torch/serialization.py", line 1492, in persistent_load
    typed_storage = load_tensor(dtype, nbytes, key, _maybe_decode_ascii(location))
  File "/Users/fabiocat/miniconda3/envs/restore/lib/python3.10/site-packages/torch/serialization.py", line 1466, in load_tensor
    wrap_storage=restore_location(storage, location),
  File "/Users/fabiocat/miniconda3/envs/restore/lib/python3.10/site-packages/torch/serialization.py", line 414, in default_restore_location
    result = fn(storage, location)
  File "/Users/fabiocat/miniconda3/envs/restore/lib/python3.10/site-packages/torch/serialization.py", line 391, in _deserialize
    device = _validate_device(location, backend_name)
  File "/Users/fabiocat/miniconda3/envs/restore/lib/python3.10/site-packages/torch/serialization.py", line 364, in _validate_device
    raise RuntimeError(f'Attempting to deserialize object on a {backend_name.upper()} '
RuntimeError: Attempting to deserialize object on a CUDA device but torch.cuda.is_available() is False. If you are running on a CPU-only machine, please use torch.load with map_location=torch.device('cpu') to map your storages to the CPU.
```

hence, I have implemented a quick solution to it by modifying the `torch.load` function to map the model to `device`.